### PR TITLE
Housekeeping: fix edgar version, doc cleanup, and enable unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,10 +33,11 @@ jobs:
 
       - name: Setup for test
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends git curl ca-certificates
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv sync --python 3.12 --no-install-project --extra dev
+          uv venv --python 3.12
+          uv pip install pytest pytest-cov pytest-timeout
+          uv pip install PyYAML omegaconf rich
+          uv pip install -e . --no-deps
 
       - name: Test
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Test
         run: |
-          uv run pytest tests/ -v --tb=short
+          .venv/bin/pytest tests/ -v --tb=short

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ default:
 
 stages:
   - lint
-  # - test  # Uncomment when tests are ready
+  - test
   - build
   - publish
 
@@ -55,25 +55,25 @@ dco-check:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 
 # =============================================================================
-# TEST STAGE (disabled for now)
+# TEST STAGE
 # =============================================================================
-# test:
-#   stage: test
-#   image: python:3.12-slim
-#   before_script:
-#     - pip install uv
-#     - uv sync --all-extras
-#   script:
-#     - uv run pytest tests/ -v --tb=short
-#   rules:
-#     # Run on merge requests
-#     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-#     # Run on main branch
-#     - if: $CI_COMMIT_BRANCH == "main"
-#     # Run on dev/ci-test branch (for testing)
-#     - if: $CI_COMMIT_BRANCH == "dev/ci-test"
-#     # Run on tags
-#     - if: $CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/
+test:
+  stage: test
+  image: python:3.12-slim
+  before_script:
+    - apt-get update && apt-get install -y git
+    - pip install uv==0.9.22
+    - uv venv --python 3.12
+    - uv pip install pytest pytest-cov pytest-timeout
+    - uv pip install PyYAML omegaconf rich
+    - uv pip install -e . --no-deps
+  script:
+    - uv run pytest tests/ -v --tb=short
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "dev"
+    - if: $CI_COMMIT_BRANCH =~ /^feature\//
 
 # =============================================================================
 # BUILD STAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ test:
     - uv pip install PyYAML omegaconf rich
     - uv pip install -e . --no-deps
   script:
-    - uv run pytest tests/ -v --tb=short
+    - .venv/bin/pytest tests/ -v --tb=short
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == "main"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ uv --version  # Should show: uv 0.9.22
 ## 📦 Installation
 
 ```bash
-git clone ssh://git@gitlab-master.nvidia.com:12051/swdl-nemollm-mlops/alignment-data/nvflow.git
+git clone https://github.com/NVIDIA/nvflow.git
 cd nvflow
 
 # For users

--- a/docs/architecture/ARCHITECTURE_INDEX.md
+++ b/docs/architecture/ARCHITECTURE_INDEX.md
@@ -137,7 +137,7 @@ The NVFlow architecture is documented across multiple files, each serving a spec
 - Online: https://mermaid.live/
 - VS Code: Mermaid Preview extension
 - CLI: `mmdc -i diagram.mmd -o diagram.png`
-- GitHub/GitLab: Native rendering
+- GitHub: Native rendering
 
 **When to Use:**
 - Need visual understanding

--- a/docs/architecture/DIAGRAMS_SUMMARY.md
+++ b/docs/architecture/DIAGRAMS_SUMMARY.md
@@ -193,7 +193,7 @@ Use Case: Cluster setup and deployment planning
 
 ## 🎨 Diagram Rendering Examples
 
-### In Markdown (GitLab/GitHub)
+### In Markdown (GitHub)
 ````markdown
 ```mermaid
 graph TB

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -322,7 +322,6 @@ env_vars:
 | `OPENAI_API_KEY` | OpenAI API access | [OpenAI Dashboard](https://platform.openai.com/api-keys) |
 | `HF_TOKEN` | Hugging Face model downloads | [HF Settings](https://huggingface.co/settings/tokens) |
 | `WANDB_API_KEY` | Weights & Biases logging | [W&B Settings](https://wandb.ai/authorize) |
-| `GITLAB_TOKEN` | GitLab API access | Your GitLab instance |
 
 **Security notes:**
 - ⚠️ **Never commit API keys to git** (config is gitignored)

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -85,8 +85,8 @@ mmdc -i deployment-architecture.mmd -o deployment-architecture.png
 mmdc -i architecture-overview.mmd -o architecture-overview.svg
 ```
 
-### Option 4: GitHub/GitLab Rendering
-GitLab and GitHub now support Mermaid diagrams natively in Markdown files. You can include them in documentation using:
+### Option 4: GitHub Rendering
+GitHub supports Mermaid diagrams natively in Markdown files. You can include them in documentation using:
 
 ````markdown
 ```mermaid

--- a/docs/recipes/finance/README.md
+++ b/docs/recipes/finance/README.md
@@ -200,4 +200,4 @@ uv run nflow run-all --config nvflow/recipes/finance/workflows/grpo/qwen3_4b.yam
 - 📖 **[Workflow Guides](workflows/)** - How to run each workflow
 - 🔧 **[Stage Reference](stages/)** - Technical specifications
 - 🚨 **[Troubleshooting Guide](troubleshooting.md)** - Solutions to common issues
-- 🐛 **GitLab Issues** - Report bugs or request features
+- 🐛 **[GitHub Issues](https://github.com/NVIDIA/nvflow/issues)** - Report bugs or request features

--- a/docs/recipes/finance/troubleshooting.md
+++ b/docs/recipes/finance/troubleshooting.md
@@ -64,7 +64,6 @@ vim $NEMO_SKILLS_CONFIG_DIR/my_cluster.yaml
 - Verify cluster has internet access
 - Check firewall rules for SEC EDGAR (sec.gov)
 - Ensure model repositories are accessible
-- Check GitLab token: `echo $GITLAB_TOKEN`
 
 ### Ray Cluster Initialization Issues (SLURM 25.11.2+)
 
@@ -321,7 +320,6 @@ ls outputs/.../checkpoints/final/
 
 **Common issues:**
 - Rate limiting: See [SEC Download Rate Limits](#sec-download-rate-limits)
-- Authentication: Ensure GITLAB_TOKEN is exported
 - Invalid tickers: Verify company symbols in config
 
 **Quick check:**
@@ -439,7 +437,7 @@ If issues persist after trying these solutions:
    - [Stage documentation](stages/)
 
 3. **Report issues:**
-   - Check existing GitLab issues
+   - Check existing [GitHub issues](https://github.com/NVIDIA/nvflow/issues)
    - Create new issue with:
      - Workflow and stage name
      - Error message (full traceback)
@@ -447,5 +445,5 @@ If issues persist after trying these solutions:
      - Environment details
 
 4. **Feature requests:**
-   - Submit GitLab issue with `[Feature Request]` tag
+   - Submit [GitHub issue](https://github.com/NVIDIA/nvflow/issues) with `[Feature Request]` tag
    - Describe use case and expected behavior

--- a/docs/recipes/finance/workflows/01-download-sec.md
+++ b/docs/recipes/finance/workflows/01-download-sec.md
@@ -15,12 +15,6 @@ Download SEC 10-K, 10-Q, and 8-K filings from the EDGAR database for specified c
 Before running this workflow, ensure you have:
 
 - ✅ **Output directory writable** (workflow creates `outputs/finance/demo/workflow-2-download-sec/step-0-download`)
-- ✅ **GitLab token exported** (for internal NVIDIA deployments):
-  ```bash
-  export GITLAB_TOKEN=<your-token>
-  ```
-  - **Why needed:** This workflow pip installs the `sec-downloader-parser` tool from an internal GitLab repository during execution
-  - **For external deployments:** This dependency can be pre-installed or replaced with an alternative SEC downloader
 
 - ✅ **SEC EDGAR identity configured** in your workflow YAML:
   ```yaml
@@ -39,15 +33,14 @@ This workflow has 2 steps:
 1. **NVFlow Stage** (`nvflow/recipes/finance/stages/download/download_sec_filings.py`)
    - Orchestrates the download job on your Slurm cluster
    - Manages containerized execution and output paths
-   - Pip installs the SEC downloader tool at runtime
 
-2. **SEC Downloader Tool** (external Python package from GitLab)
+2. **SEC Downloader Tool** (bundled in NVFlow)
    - Interfaces directly with the SEC EDGAR API
    - Downloads filings in HTML format
    - Parses and extracts individual sections (Items 1, 1A, 2, etc.) from 10-K/10-Q filings
    - Generates metadata file (`sec_metadata.parquet`) for downstream stages
 
-The NVFlow stage wraps the external tool, handling cluster integration and output management while the tool itself handles SEC API interaction and parsing.
+The NVFlow stage handles cluster integration and output management while the bundled SEC downloader tool handles SEC API interaction and parsing.
 
 ## Configuration Files
 
@@ -86,9 +79,7 @@ The NVFlow stage wraps the external tool, handling cluster integration and outpu
 
 ## Stage: sap-500
 
-Downloads SEC filings using the `sec-downloader-parser` tool ([internal NVIDIA GitLab](https://gitlab-master.nvidia.com/swdl-nemollm-mlops/alignment-data/sec-downloader-parser)).
-
-> **Note for external deployments:** The sec-downloader-parser is currently hosted on internal NVIDIA infrastructure. For external use, you can either pre-install the tool or replace it with an alternative SEC EDGAR downloader that produces the same output format.
+Downloads SEC filings using the bundled `sec-downloader-parser` tool.
 
 **See [technical reference](../stages/download-sec.md) for detailed parameters and configuration.**
 
@@ -192,17 +183,6 @@ Both SDG workflows consume the downloaded filings.
 **Solution:**
 - There was a network delay in downloading the file so the read timed out
 - Wait a few minutes and retry
-
-### Missing GitLab Token (Internal NVIDIA Only)
-
-**Symptom:** pip install fails for sec-downloader-parser
-
-**Solution:**
-```bash
-export GITLAB_TOKEN=<your-gitlab-token>
-```
-
-**Note:** See Prerequisites section above for more details on GitLab token requirements and external deployment alternatives.
 
 ### Storage Space
 

--- a/nvflow/recipes/finance/workflows/download_sec_filings.yaml
+++ b/nvflow/recipes/finance/workflows/download_sec_filings.yaml
@@ -28,7 +28,7 @@ stages:
     stage_kwargs:
       installation_command: >-
         pip install -q --root-user-action=ignore
-        edgartools sec-parser pandas pyarrow tqdm httpx tzdata &&
+        edgartools==5.20.2 sec-parser pandas pyarrow tqdm httpx tzdata &&
         ln -sfn $(python -c "import tzdata; print(tzdata.__path__[0])")/zoneinfo
         /usr/share/zoneinfo 2>/dev/null || true
 
@@ -42,6 +42,6 @@ stages:
     stage_kwargs:
       installation_command: >-
         pip install -q --root-user-action=ignore
-        edgartools sec-parser pandas pyarrow tqdm httpx tzdata &&
+        edgartools==5.20.2 sec-parser pandas pyarrow tqdm httpx tzdata &&
         ln -sfn $(python -c "import tzdata; print(tzdata.__path__[0])")/zoneinfo
         /usr/share/zoneinfo 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fix EDGAR downloader version pin (`download_sec_filings.yaml`)
- Clean up documentation: update clone URLs, issue tracker links, and rendering references for GitHub
- Enable unit tests in CI (GitHub Actions + GitLab CI) with lightweight dependency installation
- Fix `unit-tests.yml` workflow to avoid heavy `nemo-skills` dependency

## Changes

- **docs/**: Remove stale references, update issue tracker links to GitHub Issues
- **docs/recipes/finance/workflows/01-download-sec.md**: Remove internal-only prerequisites and troubleshooting sections
- **.github/workflows/unit-tests.yml**: Lightweight test setup (pytest, PyYAML, omegaconf, rich)
- **.gitlab-ci.yml**: Enable `test` stage with matching lightweight setup
- **README.md**: Update clone URL to GitHub