### PR TITLE
fix: count category-balanced capped images only for matching strategies

### DIFF
--- a/nvflow/recipes/multimodal/utils/hopchain_sample_instance_combinations.py
+++ b/nvflow/recipes/multimodal/utils/hopchain_sample_instance_combinations.py
@@ -605,7 +605,8 @@ def main() -> None:
                 )
                 if was_capped:
                     capped_images += 1
-                    category_balanced_images += 1
+                    if args.selection_strategy.startswith("balanced_by_category"):
+                        category_balanced_images += 1
                 instances, deduplicated_count = deduplicate_instances_by_bbox_iou(
                     instances,
                     iou_threshold=args.iou_dedup_threshold,


### PR DESCRIPTION
## Summary

Only increment `category_balanced_images` when a capped image was processed with a `balanced_by_category*` selection strategy. This keeps the summary metric from counting capped images produced by non-category-balanced strategies.

## Test Plan

- `python -m py_compile nvflow\recipes\multimodal\utils\hopchain_sample_instance_combinations.py`