### PR TITLE
Add test coverage for the nflow CLI

### DIFF
--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -16,3 +16,4 @@ rich
 orjson
 pandas
 pyarrow
+typer

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the ``nflow`` CLI (``nvflow.cli.main``).
+
+Exercises the Typer app end-to-end via ``CliRunner`` against the real,
+auto-discovered stage registry (the lightweight ``example`` recipe requires
+none of the heavy ``nemo-skills``/``torch`` stack, so it registers even in
+the CI-lightweight test environment -- see ``tests/requirements-ci.txt``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nvflow.cli.main import app
+
+pytest.importorskip("typer")
+
+runner = CliRunner()
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLE_CONFIG = REPO_ROOT / "nvflow/recipes/example/workflows/sdg_simple.yaml"
+
+
+class TestVersion:
+    def test_version_prints_version_string(self) -> None:
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert "NVFlow version" in result.stdout
+
+
+class TestListStages:
+    def test_no_args_lists_all_recipes(self) -> None:
+        result = runner.invoke(app, ["list-stages"])
+        assert result.exit_code == 0
+        assert "example:" in result.stdout
+        assert "generate_answer" in result.stdout
+
+    def test_filter_by_known_recipe(self) -> None:
+        result = runner.invoke(app, ["list-stages", "--recipe", "example"])
+        assert result.exit_code == 0
+        assert "example" in result.stdout
+        assert "generate_answer" in result.stdout
+
+    def test_filter_by_unknown_recipe_errors(self) -> None:
+        result = runner.invoke(app, ["list-stages", "--recipe", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.stdout
+
+    def test_filter_by_unknown_workflow_reports_no_stages(self) -> None:
+        result = runner.invoke(app, ["list-stages", "--workflow", "nonexistent_workflow"])
+        assert result.exit_code == 0
+        assert "No stages found" in result.stdout
+
+    def test_from_config_file(self) -> None:
+        result = runner.invoke(app, ["list-stages", "--config", str(EXAMPLE_CONFIG)])
+        assert result.exit_code == 0
+        assert "generate_answer" in result.stdout
+        assert "Total: 1 stages" in result.stdout
+
+    def test_from_nonexistent_config_file_errors(self) -> None:
+        result = runner.invoke(app, ["list-stages", "--config", "does_not_exist.yaml"])
+        assert result.exit_code == 1
+        assert "Error loading config" in result.stdout
+
+
+class TestStageInfo:
+    def test_full_path(self) -> None:
+        result = runner.invoke(app, ["stage-info", "example.sdg_simple.generate_answer"])
+        assert result.exit_code == 0
+        assert "GenerateAnswerStage" in result.stdout
+
+    def test_short_name_with_recipe_and_workflow(self) -> None:
+        result = runner.invoke(
+            app,
+            ["stage-info", "generate_answer", "--recipe", "example", "--workflow", "sdg_simple"],
+        )
+        assert result.exit_code == 0
+        assert "GenerateAnswerStage" in result.stdout
+
+    def test_short_name_without_recipe_and_workflow_errors(self) -> None:
+        result = runner.invoke(app, ["stage-info", "generate_answer"])
+        assert result.exit_code == 1
+        assert "must provide --recipe and --workflow" in result.stdout
+
+    def test_invalid_path_format_errors(self) -> None:
+        result = runner.invoke(app, ["stage-info", "a.b.c.d"])
+        assert result.exit_code == 1
+        assert "Invalid stage path" in result.stdout
+
+    def test_unknown_stage_errors(self) -> None:
+        result = runner.invoke(app, ["stage-info", "example.sdg_simple.nonexistent_stage"])
+        assert result.exit_code == 1
+        assert "not found" in result.stdout
+
+
+class TestValidate:
+    def test_valid_config(self) -> None:
+        result = runner.invoke(app, ["validate", "--config", str(EXAMPLE_CONFIG)])
+        assert result.exit_code == 0
+        assert "Configuration is valid" in result.stdout
+        assert "Recipe: example" in result.stdout
+
+    def test_missing_config_file_errors(self) -> None:
+        result = runner.invoke(app, ["validate", "--config", "does_not_exist.yaml"])
+        assert result.exit_code == 1
+        assert "Configuration is invalid" in result.stdout
+
+    def test_requires_config_option(self) -> None:
+        result = runner.invoke(app, ["validate"])
+        assert result.exit_code != 0
+
+
+class TestRun:
+    def test_missing_config_file_errors(self) -> None:
+        result = runner.invoke(app, ["run", "generate_answer", "--config", "does_not_exist.yaml"])
+        assert result.exit_code == 1
+        assert "Error:" in result.stdout
+
+    def test_requires_config_option(self) -> None:
+        result = runner.invoke(app, ["run", "generate_answer"])
+        assert result.exit_code != 0
+
+
+class TestRunAll:
+    def test_missing_config_file_errors(self) -> None:
+        result = runner.invoke(app, ["run-all", "--config", "does_not_exist.yaml"])
+        assert result.exit_code == 1
+        assert "Error:" in result.stdout


### PR DESCRIPTION
## Summary

`nvflow/cli/main.py` (the `list-stages`, `run`, `run-all`, `validate`, `stage-info` commands) had zero dedicated test coverage. `tests/test_cli_cmd.py` tests a different module (`nvflow/lib/cli_cmd.py`, a shell-command builder) with a similarly-named file — easy to mistake for CLI coverage, but it isn't.

This PR adds `tests/test_cli_main.py`, using `typer.testing.CliRunner` against the real Typer app and the real auto-discovered stage registry (via the `example` recipe, which needs none of the heavy `nemo-skills`/`torch` stack, so it registers correctly even in the CI-lightweight test environment described in `tests/requirements-ci.txt`).

Coverage:
- `version`
- `list-stages`: no args, `--recipe`, unknown recipe, unknown workflow, `--config`, missing config file
- `stage-info`: full path, short name + `--recipe`/`--workflow`, short name missing those options, invalid path format, unknown stage
- `validate`: valid config, missing config file, missing `--config` option
- `run` / `run-all`: missing config file, missing `--config` option

Also adds `typer` to `tests/requirements-ci.txt` — without it, this test file can't even be collected in the lightweight CI environment (`nvflow.cli.main` imports `typer` directly), so this was necessary for the new tests to actually run in CI rather than error at collection.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `mypy` passes on the new file
- [x] New suite passes (18/18) against the real CLI in an environment mirroring the exact CI install (`pip install -e . --no-deps` + `tests/requirements-ci.txt`, no `nemo-skills`/`torch`)
- [x] Full existing `pytest tests/` suite still passes (371 passed, 3 pre-existing skips, unrelated to this change) in the same environment -- confirms no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)