### PR TITLE
Fix stale retail/healthcare recipe references and placeholder package metadata

### DIFF
--- a/nvflow/cli/main.py
+++ b/nvflow/cli/main.py
@@ -165,7 +165,7 @@ def list_stages(
         None, "--config", "-c", help="Optional: Show only stages defined in this config file"
     ),
     recipe: str | None = typer.Option(
-        None, "--recipe", "-r", help="Optional: Filter by recipe (finance, retail, healthcare)"
+        None, "--recipe", "-r", help="Optional: Filter by recipe (finance, example, multimodal)"
     ),
     workflow: str | None = typer.Option(
         None, "--workflow", "-w", help="Optional: Filter by workflow (training_sft, sdg_basic)"

--- a/nvflow/core/stage_registry.py
+++ b/nvflow/core/stage_registry.py
@@ -40,7 +40,7 @@ class StageRegistry:
     """Hierarchical registry for workflow stages.
 
     Stages are organized in a three-level hierarchy:
-    - Recipe (e.g., "finance", "retail")
+    - Recipe (e.g., "finance", "multimodal")
     - Workflow (e.g., "training_sft", "sdg_basic")
     - Stage (e.g., "baseline", "generate_qa")
 
@@ -70,7 +70,7 @@ class StageRegistry:
         """Decorator to register a stage class in the hierarchy.
 
         Args:
-            recipe: Recipe name (e.g., "finance", "retail")
+            recipe: Recipe name (e.g., "finance", "multimodal")
             workflow: Workflow name within recipe (e.g., "training_sft", "sdg_basic")
             stage: Stage name within workflow (e.g., "baseline", "generate_qa")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nvflow"
 dynamic = ["version"]  # Version determined from git tags via hatch-vcs
 description = "Workflow orchestration for end-to-end model training on NeMo ecosystem"
 authors = [
-    {name = "Your Team", email = "team@example.com"}
+    {name = "NVIDIA Corporation"}
 ]
 readme = "README.md"
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
## Summary

Two small doc/metadata drift issues found while reviewing the codebase:

1. **Non-existent example recipes in docs/help text.** `nvflow/cli/main.py`'s `--recipe` option help text and `nvflow/core/stage_registry.py`'s `register()`/class docstrings reference `retail` and `healthcare` as example recipes. Only `finance`, `example`, and `multimodal` recipes exist anywhere in the codebase (confirmed via `@StageRegistry.register` call sites) — `retail`/`healthcare` look like leftover placeholder names from before the repo's public release. Updated the examples to real recipe names.

2. **Placeholder package metadata.** `pyproject.toml` shipped `authors = [{name = "Your Team", email = "team@example.com"}]` — an unfilled template placeholder in the public release. Replaced with `"NVIDIA Corporation"`. Happy to adjust to a specific team alias/email if maintainers prefer one — I didn't want to guess at an internal contact.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `pyproject.toml` still parses as valid TOML after the edit
- [x] Full `pytest tests/` suite passes (339 passed, 3 pre-existing skips) — no code behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)